### PR TITLE
Fix passthrough mode

### DIFF
--- a/drivers/md/dm-cache-policy-smq.c
+++ b/drivers/md/dm-cache-policy-smq.c
@@ -1589,14 +1589,18 @@ static int smq_invalidate_mapping(struct dm_cache_policy *p, dm_cblock_t cblock)
 {
 	struct smq_policy *mq = to_smq_policy(p);
 	struct entry *e = get_entry(&mq->cache_alloc, from_cblock(cblock));
+	unsigned long flags;
 
 	if (!e->allocated)
 		return -ENODATA;
 
+	spin_lock_irqsave(&mq->lock, flags);
 	// FIXME: what if this block has pending background work?
 	del_queue(mq, e);
 	h_remove(&mq->table, e);
 	free_entry(&mq->cache_alloc, e);
+	spin_unlock_irqrestore(&mq->lock, flags);
+
 	return 0;
 }
 

--- a/drivers/md/dm-cache-target.c
+++ b/drivers/md/dm-cache-target.c
@@ -1456,8 +1456,10 @@ static void invalidate_complete(struct dm_cache_migration *mg, bool success)
 	struct cache *cache = mg->cache;
 
 	bio_list_init(&bios);
-	if (dm_cell_unlock_v2(cache->prison, mg->cell, &bios))
-		free_prison_cell(cache, mg->cell);
+	if (mg->cell) {
+		if (dm_cell_unlock_v2(cache->prison, mg->cell, &bios))
+			free_prison_cell(cache, mg->cell);
+	}
 
 	if (!success && mg->overwrite_bio)
 		bio_io_error(mg->overwrite_bio);


### PR DESCRIPTION
## Summary by Sourcery

Improve cache invalidation and passthrough I/O handling in dm-cache-target and enhance safety in SMQ policy invalidation.

New Features:
- Introduce a retry handler for failed invalidation locks to defer and retry overwrite bios
- Add a new invalidate_committed worker to remap, hook, and submit overwrite bios after commit

Bug Fixes:
- Ensure overwrite bios always complete with a proper status via bio_endio and guarded bi_status setting
- Guard against unlocking a null prison cell in invalidation completion
- Return DM_MAPIO_SUBMITTED from map_bio when starting invalidation to correctly signal I/O submission
- Protect SMQ policy invalidate_mapping against concurrent modifications by adding spinlock around entry removal

Enhancements:
- Consolidate continuation in invalidate_remove to use the new invalidate_committed path